### PR TITLE
allow script to use per-user config files

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ Just fetch this repo with git:
 `git clone git://github.com/vehk/mpdnotify.git`
 
 ### Usage
-Configure the script by editing the 'mpdnotify' file.
+$XDG_CONFIG_HOME/mpdnotify.conf is created the first time the script is executed.
+Edit it to match your system setup.
 
 The only thing left to do is to set up a program that will run
 the script whenever a new song is playing.

--- a/mpdnotify
+++ b/mpdnotify
@@ -14,9 +14,21 @@
 # (Just make sure not to hurt any kittens)
 # https://github.com/graysky2/mpdnotify
 
-# Configuration-------------------------------------------------------
+# make sure env var is setup correctly
+[[ -z "$XDG_CONFIG_HOME" ]] && \
+		XDG_CONFIG_HOME="$HOME/.config"
 
-# Note that mpc may require you to set the MPD_HOST variable in order 
+CFG_FILE=$XDG_CONFIG_HOME/mpdnotify.conf
+
+if [[ ! -f "$CFG_FILE" ]]; then
+		echo '------------------------------------------------------------'
+		echo ' No config file found so creating a fresh one.'
+		echo
+		cat <<EOF > $XDG_CONFIG_HOME/mpdnotify.conf
+#
+# $XDG_CONFIG_HOME/mpdnotify.conf
+#
+# Note that mpc may require you to set the MPD_HOST variable in order
 # to function correctly with this script. Uncomment the MPD_HOST variable
 # and set it manually if this is the case on your system.
 #
@@ -56,6 +68,13 @@ COVER_BACKGROUND="none"
 
 # Logfile
 LOGFILE="$HOME/.mpdnotify.log"
+EOF
+		echo ' Edit $XDG_CONFIG_HOME/mpdnotify.conf for this system.'
+		echo '------------------------------------------------------------'
+		exit 1
+else
+		. "$CFG_FILE"
+fi
 
 #--------------------------------------------------------------------
 
@@ -102,4 +121,3 @@ if [[ -n $cover ]]; then
 else
     notify-send -t 5000 --hint=int:transient:1 "$NOTIFY_TITLE" "$text" >> "$LOGFILE" 2>&1
 fi
-


### PR DESCRIPTION
I have mine in /usr/local/bin/mpdnotify which multiple users make use of... with this modification, each user gets his/her own ~/.config/mpdnotify.conf in which user-specific settings can be stored.
